### PR TITLE
Update version and cleanup chocolatey scripts.

### DIFF
--- a/rabbitmq.nuspec
+++ b/rabbitmq.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>rabbitmq</id>
     <title>RabbitMQ</title>
-    <version>3.5.4</version>
+    <version>3.6.2</version>
     <authors>GoPivotal</authors>
     <owners>Scott Smerchek</owners>
     <summary>RabbitMQ - Messaging that just works</summary>
@@ -14,13 +14,8 @@ The RabbitMQ Chocolatey package source has a new home at https://github.com/tnwi
 #### Package Parameters
 
  * `/NOMANAGEMENT` - this setting will override the default enabling of the RabbitMQ management console'
- * `/RABBITMQBASE` - specify an optional RABBITMQ_BASE. Note the parameter has no underscore, but the environment variable does. ex:/RABBITMQBASE:C:\ProgramData\RabbitMQ. The default is %AppData\RabbitMQ'
-
-3.5.3: Un-installation is now silent, no user interaction is required.
-3.5.4: Smarter upgrade by removing first
-       Remove erlang service on uninstall if needed
- 
-	</description>
+ * `/RABBITMQBASE` - specify an optional RABBITMQ_BASE. Note the parameter has no underscore, but the environment variable does. ex:/RABBITMQBASE:C:\ProgramData\RabbitMQ. The default is %AppData\RabbitMQ' 
+  </description>
     <projectUrl>http://www.rabbitmq.com/</projectUrl>
     <tags>message queueing messaging admin</tags>
     <copyright>GoPivotal, Inc.</copyright>
@@ -32,8 +27,4 @@ The RabbitMQ Chocolatey package source has a new home at https://github.com/tnwi
     </dependencies>
     <releaseNotes></releaseNotes>
   </metadata>
-  <files>
-    <file src="tools\**" target="tools" />
-    <!--<file src="content\**" target="content" />-->
-  </files>
 </package>

--- a/test.bat
+++ b/test.bat
@@ -1,4 +1,0 @@
-@echo off
-del *.nupkg
-choco pack
-choco install rabbitmq -fdvy -s "%cd%"

--- a/tools/chocolateyHelpers.ps1
+++ b/tools/chocolateyHelpers.ps1
@@ -1,0 +1,33 @@
+function Get-ChocolateyPackageParameters {
+  $match_pattern = "\/(?<option>([a-zA-Z]+)):(?<value>([`"'])?([a-zA-Z0-9- _\\:\.]+)([`"'])?)|\/(?<option>([a-zA-Z]+))"
+  $arguments = @{}
+  $packageParameters = ${Env:ChocolateyPackageParameters}
+
+  if ($packageParameters) {
+    if ($packageParameters -Match $match_pattern) {
+      $results = $packageParameters | Select-String $match_pattern -AllMatches
+      $results.matches | % {
+        $arguments.Add(
+        $_.Groups['option'].Value.Trim(),
+        $_.Groups['value'].Value.Trim())
+      }
+    } else {
+      throw "Package Parameters were found but were invalid (REGEX Failure)"
+    }
+  }
+
+  return $arguments
+}
+
+function Get-RabbitMQPath {
+  $regPath = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\RabbitMQ"
+  if (Test-Path "HKLM:\SOFTWARE\Wow6432Node\") {
+    $regPath = "HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\RabbitMQ"
+  }
+  
+  if (Test-Path $regPath) {
+    $path = Split-Path -Parent (Get-ItemProperty $regPath "UninstallString").UninstallString
+    $version = (Get-ItemProperty $regPath "DisplayVersion").DisplayVersion
+    return "$path\rabbitmq_server-$version"
+  }
+}

--- a/tools/chocolateyInstall.ps1
+++ b/tools/chocolateyInstall.ps1
@@ -1,83 +1,19 @@
-﻿#choco install rabbitmq -s '%cd%' -f --params="/RABBITMQBASE:C:\ProgramData\RabbitMQ"
+﻿if(!$PSScriptRoot){ $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent }
+. "$PSScriptRoot\ChocolateyHelpers.ps1"
 
+$arguments = Get-ChocolateyPackageParameters ${Env:ChocolateyPackageParameters}
 
-function Get-RabbitMQPath
-{
-    $regPath = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\RabbitMQ"
-    if (Test-Path "HKLM:\SOFTWARE\Wow6432Node\") { $regPath = "HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\RabbitMQ" }
-    if (!(Test-Path $regPath)) { return $false }
-    $path = Split-Path -Parent (Get-ItemProperty $regPath "UninstallString").UninstallString
-    $version = (Get-ItemProperty $regPath "DisplayVersion").DisplayVersion
-    return "$path\rabbitmq_server-$version"
+if ($arguments['RABBITMQBASE']) {
+  [System.Environment]::SetEnvironmentVariable("RABBITMQ_BASE", $arguments['RABBITMQBASE'], "Machine" )
+  ${Env:RABBITMQ_BASE} = $arguments['RABBITMQBASE']
 }
 
-##This whole arguments section lifted shamelessly from the git.install package. Thanks guys!
-$arguments = @{};
-# /RabbitMQBase /GitAndUnixToolsOnPath /NoAutoCrlf
-$packageParameters = $env:chocolateyPackageParameters;
-
-# Now parse the packageParameters using good old regular expression
-if ($packageParameters) {
-	$match_pattern = "\/(?<option>([a-zA-Z]+)):(?<value>([`"'])?([a-zA-Z0-9- _\\:\.]+)([`"'])?)|\/(?<option>([a-zA-Z]+))"
-	$option_name = 'option'
-	$value_name = 'value'
-
-	if ($packageParameters -match $match_pattern ){
-	$results = $packageParameters | Select-String $match_pattern -AllMatches
-		$results.matches | % {
-			$arguments.Add(
-			$_.Groups[$option_name].Value.Trim(),
-			$_.Groups[$value_name].Value.Trim())
-		}
-	}
-	else
-	{
-		throw "Package Parameters were found but were invalid (REGEX Failure)"
-	}
-}
-
-
-
-
-
-if ($arguments['RABBITMQBASE'])
-{
-    Write-Output "Setting RABBITMQ_BASE"
-    [System.Environment]::SetEnvironmentVariable("RABBITMQ_BASE", $arguments['RABBITMQBASE'], "Machine" )
-    $ENV:RABBITMQ_BASE = $arguments['RABBITMQBASE']
-}
-
-$toolsDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-
-
-#this tests to see if RabbitMQ is installed and removes it
-if (Get-RabbitMQPath)
-{
-    Write-Output "RabbitMQ found, removing..."
-    . "$toolsDir\chocolateyUninstall.ps1"
-    Write-Output "RabbitMQ found, removed"
-}
-
-#now install
-Install-ChocolateyPackage 'rabbitmq' 'EXE' '/S' 'http://www.rabbitmq.com/releases/rabbitmq-server/v3.5.4/rabbitmq-server-3.5.4.exe' -validExitCodes @(0)
-
+Install-ChocolateyPackage 'rabbitmq' 'EXE' '/S' 'http://www.rabbitmq.com/releases/rabbitmq-server/v3.6.2/rabbitmq-server-3.6.2.exe'
 
 $rabbitPath = Get-RabbitMQPath
-Start-Process -wait "$rabbitPath\sbin\rabbitmq-service.bat" "stop"
-
-if (!($arguments['NOMANAGEMENT']))
-{
-    Start-Process -wait "$rabbitPath\sbin\rabbitmq-service.bat" "enable rabbitmq_management --offline"
-	Start-Process -wait "$rabbitPath\sbin\rabbitmq-plugins.bat" "enable rabbitmq_management"
+if (-not $arguments.ContainsKey('NOMANAGEMENT')) {
+  Start-Process "$rabbitPath\sbin\rabbitmq-service.bat" 'enable rabbitmq_management --offline' -NoNewWindow -Wait
+  Start-Process "$rabbitPath\sbin\rabbitmq-plugins.bat" 'enable rabbitmq_management' -NoNewWindow -Wait
 }
 
-Start-Process -wait "$rabbitPath\sbin\rabbitmq-service.bat" "install"
-Start-Process -wait "$rabbitPath\sbin\rabbitmq-service.bat" "start"
-
-
-#Start-ChocolateyProcessAsAdmin $target
-				    
-echo ""
-echo "RabbitMQ Management Plugin enabled by default at http://localhost:15672"
-echo ""
-
+Start-Process "$rabbitPath\sbin\rabbitmq-service.bat" 'install' -NoNewWindow -Wait

--- a/tools/chocolateyUninstall.ps1
+++ b/tools/chocolateyUninstall.ps1
@@ -1,20 +1,12 @@
-﻿function Get-RabbitMQPath
-{
-    $regPath = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\RabbitMQ"
-    if (Test-Path "HKLM:\SOFTWARE\Wow6432Node\") { $regPath = "HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\RabbitMQ" }
-    $path = Split-Path -Parent (Get-ItemProperty $regPath "UninstallString").UninstallString
-    $version = (Get-ItemProperty $regPath "DisplayVersion").DisplayVersion
-    return "$path\rabbitmq_server-$version"
-}
+﻿if(!$PSScriptRoot){ $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent }
+. "$PSScriptRoot\ChocolateyHelpers.ps1"
 
 $rabbitPath = Get-RabbitMQPath
 
-start-process -wait "$rabbitPath\..\uninstall" "/S"
+Start-Process -Wait "$rabbitPath\..\uninstall" "/S"
 
 $erlangKey = "HKLM:\SOFTWARE\Ericsson\Erlang\ErlSrv\1.1\RabbitMQ"
-
-if (Test-Path $erlangKey)
-{
-    Get-Process | Where-Object {$_.ProcessName -like "*erl*"} | Stop-Process -Force
-    Remove-Item $erlangKey
+if (Test-Path $erlangKey) {
+  Get-Process | Where-Object {$_.ProcessName -like "*erl*"} | Stop-Process -Force
+  Remove-Item $erlangKey
 }

--- a/tools/fudd.bat
+++ b/tools/fudd.bat
@@ -1,9 +1,0 @@
-@echo off
-start /wait c:\progra~2\rabbit~1\uninstall.exe
-pause
-taskkill /f /im epmd.exe
-taskkill /f /im erl.exe
-pause
-rmdir /s /q %appdata%\RabbitMQ
-rmdir /s /q c:\programdata\rabbitmq
-@powershell -command "[System.Environment]::SetEnvironmentVariable('RABBITMQ_BASE', '','Machine' )"


### PR DESCRIPTION
The intent of this change is to bump the rabbitmq version to the 3.6.2 version. As part of this change, I cleaned up the whitespace, indentation, comments, and tabbing with the goal of making a smaller chocolateyinstall.ps1 file that is easier to skim when reviewing the package. I also consolidated the helper code to a helpers file and made some other minor modifications.

Tested  with:

```
choco install rabbitmq --source .\ -y
choco uninstall rabbitmq -y
choco install rabbitmq --source .\ --params="/RABBITMQBASE=C:\rabbit /NOMANAGEMENT"
choco uninstall rabbitmq -y
```

I have a couple of questions that I've asked in the PR comments.
